### PR TITLE
Potential fix for code scanning alert no. 3: Call to eval-like DOM function

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
 // Vulnerable to reflected XSS
 const userInput = location.hash.slice(1);  // Takes untrusted input from URL fragment
-document.write(userInput);                  // Writes input directly to the page without sanitization
+const outputElement = document.getElementById('output');  // Assume an element with ID 'output' exists
+outputElement.textContent = userInput;                    // Safely display input as plain text


### PR DESCRIPTION
Potential fix for [https://github.com/faozt10/testghas/security/code-scanning/3](https://github.com/faozt10/testghas/security/code-scanning/3)

To fix the issue, we need to replace the use of `document.write` with a safer alternative. Specifically:
1. Use DOM manipulation methods like `textContent` or `innerText` to safely display user input as plain text.
2. If the input is intended to include HTML, sanitize it using a library like `DOMPurify` to remove potentially harmful content.
3. Update the code to ensure that untrusted input is handled securely.

In this case, we will assume the input should be displayed as plain text. This avoids the need for HTML sanitization and ensures the content is safe.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
